### PR TITLE
CI: Remove --ignore-requires-python

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,7 @@ jobs:
         sudo apt-get install -y fftw3-dev
         python -m pip install Cython
     - name: Install app
-      run: python -m pip install --ignore-requires-python -e ."$EXTRAS"
+      run: python -m pip install -e ."$EXTRAS"
       env:
         EXTRAS: '${{ matrix.extras }}'
     - name: Run app with coverage


### PR DESCRIPTION
Remove the --ignore-requires-python flag to make pip pick a numpy version that works with a given python version